### PR TITLE
Ectoplasm chance

### DIFF
--- a/src/main/java/chylex/hee/block/BlockSpookyLog.java
+++ b/src/main/java/chylex/hee/block/BlockSpookyLog.java
@@ -45,7 +45,7 @@ public class BlockSpookyLog extends Block{
 	public void dropBlockAsItemWithChance(World world, int x, int y, int z, int meta, float chance, int fortune){
 		super.dropBlockAsItemWithChance(world,x,y,z,meta,chance,fortune);
 		
-		if (meta > 0 && !world.isRemote && world.rand.nextInt(4) == 0){
+		if (meta > 0 && !world.isRemote && world.rand.nextInt(25) <= 15){
 			EntityPlayer closest = null;
 			double curDist = 8D;
 			
@@ -66,7 +66,7 @@ public class BlockSpookyLog extends Block{
 					if ((is = closest.inventory.getStackInSlot(a)) == null)continue;
 					
 					if (is.getItem() == ItemList.ghost_amulet && is.getItemDamage() == 1){
-						if (world.rand.nextInt(5) <= 1)dropBlockAsItem(world,x,y,z,new ItemStack(ItemList.ectoplasm));
+						dropBlockAsItem(world,x,y,z,new ItemStack(ItemList.ectoplasm));
 						
 						PacketPipeline.sendToPlayer(closest,new C08PlaySound(C08PlaySound.GHOST_DEATH,closest.posX,closest.posY,closest.posZ,1.8F,0.9F+world.rand.nextFloat()*0.3F));
 						

--- a/src/main/java/chylex/hee/block/BlockSpookyLog.java
+++ b/src/main/java/chylex/hee/block/BlockSpookyLog.java
@@ -45,7 +45,7 @@ public class BlockSpookyLog extends Block{
 	public void dropBlockAsItemWithChance(World world, int x, int y, int z, int meta, float chance, int fortune){
 		super.dropBlockAsItemWithChance(world,x,y,z,meta,chance,fortune);
 		
-		if (meta > 0 && !world.isRemote && world.rand.nextInt(25) <= 15){
+		if (meta > 0 && !world.isRemote && world.rand.nextInt(4) <= 2){
 			EntityPlayer closest = null;
 			double curDist = 8D;
 			

--- a/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
@@ -324,7 +324,8 @@ ec.reg.432=Each log has a 1 in 8 (12.5%%) chance of dropping a $i:~dry_splinter.
 ec.reg.433=In the Deep variation of $d:InfestedForest:Infested Forest$, some trees have faces.
 ec.reg.434=When nobody looks at a face, it will move around the tree or move to another nearby tree.
 ec.reg.435=If a log with a face is broken, it has a 1 in 4 (25%%) chance of spawning a Forest Ghost.
-ec.reg.436=$i:~ghost_amulet will stop the Forest Ghost from spawning, and the face will have a 3 in 5 (60%%) chance to drop $i:~endoplasm.
+ec.reg.436=$i:~ghost_amulet will stop the Forest Ghost from spawning, and the face will have a 1 in 4 (25%%) chance to
+drop $i:~endoplasm.
 
 ec.reg.440=Spooky Leaves are foliage of the Spooky Trees.
 ec.reg.441=If not connected to a $b:~spooky_log, they leaves very quickly decay.
@@ -333,7 +334,8 @@ ec.reg.450=Crafting material dropped by $b:~spooky_log.
 ec.reg.451=Each $b:~spooky_log has 1 in 8 (12.5%%) chance of dropping a $i:~dry_splinter.
 
 ec.reg.460=An amulet that banishes the Forest Ghost.
-ec.reg.461=When in the inventory, Forest Ghost will not spawn and the $b:~spooky_log face will have 3 in 5 (60%%) chance to drop $i:~endoplasm.
+ec.reg.461=When in the inventory, Forest Ghost will not spawn and the $b:~spooky_log face will have 1 in 4 (25%%) chance
+ to drop $i:~endoplasm.
 ec.reg.462=In order to create it, one piece of $i:~end_powder, Emerald and String all have to be thrown into $i:~bucket_ender_goo:Ender Goo$.
 ec.reg.463=Then it has to be purified in $b:~essence_altar/1.
 

--- a/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
@@ -324,8 +324,7 @@ ec.reg.432=Each log has a 1 in 8 (12.5%%) chance of dropping a $i:~dry_splinter.
 ec.reg.433=In the Deep variation of $d:InfestedForest:Infested Forest$, some trees have faces.
 ec.reg.434=When nobody looks at a face, it will move around the tree or move to another nearby tree.
 ec.reg.435=If a log with a face is broken, it has a 1 in 4 (25%%) chance of spawning a Forest Ghost.
-ec.reg.436=$i:~ghost_amulet will stop the Forest Ghost from spawning, and the face will have a 1 in 4 (25%%) chance to
-drop $i:~endoplasm.
+ec.reg.436=$i:~ghost_amulet will stop the Forest Ghost from spawning, and the face will have a 1 in 4 (25%%) chance to drop $i:~endoplasm.
 
 ec.reg.440=Spooky Leaves are foliage of the Spooky Trees.
 ec.reg.441=If not connected to a $b:~spooky_log, they leaves very quickly decay.
@@ -334,8 +333,7 @@ ec.reg.450=Crafting material dropped by $b:~spooky_log.
 ec.reg.451=Each $b:~spooky_log has 1 in 8 (12.5%%) chance of dropping a $i:~dry_splinter.
 
 ec.reg.460=An amulet that banishes the Forest Ghost.
-ec.reg.461=When in the inventory, Forest Ghost will not spawn and the $b:~spooky_log face will have 1 in 4 (25%%) chance
- to drop $i:~endoplasm.
+ec.reg.461=When in the inventory, Forest Ghost will not spawn and the $b:~spooky_log face will have 1 in 4 (25%%) chance to drop $i:~endoplasm.
 ec.reg.462=In order to create it, one piece of $i:~end_powder, Emerald and String all have to be thrown into $i:~bucket_ender_goo:Ender Goo$.
 ec.reg.463=Then it has to be purified in $b:~essence_altar/1.
 


### PR DESCRIPTION
Changed the ectoplasm chance to actually match Ender Compendium explanation on the drop rate
![javaw_qU7eW990pt](https://user-images.githubusercontent.com/17811922/126877239-a60a8ad7-154a-470d-aaee-bfd43b278c34.png)

I looked at the code and saw the differences while trying to do the quests to unlock draconic evolution and getting really frustrated on the drop rate of ectoplasm from the spooky trees