### PR TITLE
fix dragon attacking creative player

### DIFF
--- a/src/main/java/chylex/hee/entity/boss/dragon/managers/DragonAttackManager.java
+++ b/src/main/java/chylex/hee/entity/boss/dragon/managers/DragonAttackManager.java
@@ -79,11 +79,9 @@ public class DragonAttackManager {
                 EntityPlayer.class,
                 AxisAlignedBB.getBoundingBox(-160D, -32D, -160D, 160D, 512D, 160D));
 
-        if (players.size() > 1) {
-            for (Iterator<EntityPlayer> iter = players.iterator(); iter.hasNext();) {
-                EntityPlayer player = iter.next();
-                if (player.capabilities.isCreativeMode || player.isDead) iter.remove();
-            }
+        for (Iterator<EntityPlayer> iter = players.iterator(); iter.hasNext();) {
+            EntityPlayer player = iter.next();
+            if (player.capabilities.isCreativeMode || player.isDead) iter.remove();
         }
 
         return players;


### PR DESCRIPTION
DragonAttackManager already filters out dead or creative players, but only if there is more than one player present.
If only one player is present, they would be attacked, even if they are dead or in creative mode, which is annoying.

The purpose of why the >1 check was even there isn't clear; the dragon seems fully capable of working while having no eligible target players. Briefly tested to work in singleplayer.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17543