### PR TITLE
Fix music disk use in the GT electric jukebox by adding metadata

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    implementation('com.github.GTNewHorizons:GTNHLib:0.5.15:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.5.22:dev')
     implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.42-GTNH:dev')
 
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = chylex.hee.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = HardcoreEnderExpansion.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/chylex/hee/HardcoreEnderExpansion.java
+++ b/src/main/java/chylex/hee/HardcoreEnderExpansion.java
@@ -60,10 +60,10 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 @Mod(
         modid = "HardcoreEnderExpansion",
         name = "Hardcore Ender Expansion",
-        version = "GRADLETOKEN_VERSION",
+        version = Tags.VERSION,
         useMetadata = true,
         guiFactory = "chylex.hee.gui.core.ModGuiFactory",
-        dependencies = "required-after:gtnhlib@[0.0.10,)")
+        dependencies = "required-after:gtnhlib@[0.5.22,)")
 public class HardcoreEnderExpansion {
 
     @Instance("HardcoreEnderExpansion")

--- a/src/main/java/chylex/hee/item/ItemMusicDisk.java
+++ b/src/main/java/chylex/hee/item/ItemMusicDisk.java
@@ -2,6 +2,7 @@ package chylex.hee.item;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockJukebox;
@@ -22,6 +23,8 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
+import com.gtnewhorizon.gtnhlib.api.MusicRecordMetadataProvider;
+
 import chylex.hee.packets.PacketPipeline;
 import chylex.hee.packets.client.C02PlayRecord;
 import chylex.hee.system.util.BlockPosM;
@@ -29,7 +32,7 @@ import chylex.hee.system.util.MathUtil;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class ItemMusicDisk extends ItemRecord {
+public class ItemMusicDisk extends ItemRecord implements MusicRecordMetadataProvider {
 
     private static final List<String[]> musicNames = new ArrayList<>();
     private static final List<ResourceLocation> musicResources = new ArrayList<>();
@@ -59,6 +62,19 @@ public class ItemMusicDisk extends ItemRecord {
 
     public static ResourceLocation getRecordResource(int damage) {
         return musicResources.get(MathUtil.clamp(damage, 0, musicNames.size() - 1));
+    }
+
+    @Override
+    public ResourceLocation getMusicRecordResource(ItemStack stack) {
+        if (stack == null || !(stack.getItem() instanceof ItemMusicDisk)) {
+            return null;
+        }
+        return getRecordResource(stack.getItemDamage());
+    }
+
+    @Override
+    public Iterable<ItemStack> getMusicRecordVariants() {
+        return IntStream.range(0, musicNames.size()).mapToObj(i -> new ItemStack(this, 1, i))::iterator;
     }
 
     private IIcon[] iconArray;

--- a/src/main/resources/soundmeta/durations.json
+++ b/src/main/resources/soundmeta/durations.json
@@ -1,0 +1,14 @@
+{
+  "soundDurationsMs": {
+    "hardcoreenderexpansion:records.qwertygiy.asteroid": 58254,
+    "hardcoreenderexpansion:records.qwertygiy.banjolic": 94350,
+    "hardcoreenderexpansion:records.qwertygiy.beatthedragon": 114731,
+    "hardcoreenderexpansion:records.qwertygiy.cryingsoul": 130240,
+    "hardcoreenderexpansion:records.qwertygiy.granite": 130288,
+    "hardcoreenderexpansion:records.qwertygiy.intheend": 213146,
+    "hardcoreenderexpansion:records.qwertygiy.onion": 207758,
+    "hardcoreenderexpansion:records.qwertygiy.rememberthis": 85717,
+    "hardcoreenderexpansion:records.qwertygiy.spyder": 133695,
+    "hardcoreenderexpansion:records.qwertygiy.stewed": 85416
+  }
+}


### PR DESCRIPTION
Add the required music metadata to HEE disks to allow playing them in the electric jukebox. Tested locally using a GT5u build that I'll PR once I also test Botania music.