### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/hardcoreenderexpansion/lang/en_US.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/en_US.lang
@@ -2,12 +2,15 @@
 tile.baconStone.name=Bacon Stone
 tile.obsidianEnd.name=Falling Obsidian
 tile.obsidianStairs.name=Obsidian Stairs
+tile.obsidianSpecial.name=Obsidian
 tile.obsidianSpecial.smooth.name=Smooth Obsidian
 tile.obsidianSpecial.chiseled.name=Chiseled Obsidian
 tile.obsidianSpecial.pillar.name=Obsidian Pillar
+tile.obsidianSpecial.name=Glowing Obsidian
 tile.obsidianSpecialGlowing.smooth.name=Smooth Glowing Obsidian
 tile.obsidianSpecialGlowing.chiseled.name=Chiseled Glowing Obsidian
 tile.obsidianSpecialGlowing.pillar.name=Glowing Obsidian Pillar
+tile.essenceAltar.name=Essence Altar
 tile.essenceAltar.basic.name=Basic Essence Altar
 tile.essenceAltar.dragon.name=Dragon Essence Altar
 tile.essenceAltar.dragon.bacon.name=Bacon Essence Altar
@@ -30,6 +33,7 @@ tile.instabilityOrbOre.name=Instability Orb Ore
 tile.enderGoo.name=Ender Goo
 tile.endiumBlock.name=Endium Block
 tile.endiumBlock.bacon.name=Baconium Block
+tile.endStoneTerrain.name=End Stone
 tile.endStoneTerrain.infested.name=Infested End Stone
 tile.endStoneTerrain.burned.name=Burned End Stone
 tile.endStoneTerrain.enchanted.name=Enchanted End Stone
@@ -47,6 +51,7 @@ tile.crossedDecoration.violetMoss.moderate.name=Moderate Violet Moss
 tile.crossedDecoration.violetMoss.short.name=Short Violet Moss
 tile.crossedDecoration.flameweed.name=Flameweed
 tile.crossedDecoration.shadowOrchid.name=Shadow Orchid
+item.endermanHead.name=Enderman Head
 tile.endermanHead.name=Enderman Head
 tile.endermanHead.bacon.name=Baconman Head
 tile.sphalerite.name=Sphalerite
@@ -57,6 +62,7 @@ tile.ravagedBrickGlow.name=Glowing Ravaged Brick
 tile.ravagedBrickSlab.name=Ravaged Brick Slab
 tile.ravagedBrickStairs.name=Ravaged Brick Stairs
 tile.ravagedBrickFence.name=Ravaged Brick Fence
+tile.dungeonPuzzle.name=Dungeon Puzzle
 tile.dungeonPuzzle.wall.name=Dungeon Puzzle (Wall)
 tile.dungeonPuzzle.rock.name=Dungeon Puzzle (Rock)
 tile.dungeonPuzzle.ceiling.name=Dungeon Puzzle (Ceiling)
@@ -83,6 +89,9 @@ tile.brewingStand.name=Enhanced Brewing Stand
 tile.templeEndPortal.name=End Portal
 tile.laserBeam.name=Laser Beam
 
+tile.crossedDecoration.name=Crossed Decoration
+
+item.essence.name=Essence
 item.essence.dragon.name=Dragon Essence
 item.essence.dragon.bacon.name=Bacon Essence
 item.essence.fiery.name=Fiery Essence
@@ -153,6 +162,7 @@ item.sacredWand.core.dexterity=Dexterity Wand Core
 item.sacredWand.core.force=Force Wand Core
 item.sacredWand.core.repulsion=Repulsion Wand Core
 
+item.rune.name=Rune
 item.rune.any.name=Rune (Any)
 item.rune.power.name=Rune of Power
 item.rune.agility.name=Rune of Agility
@@ -161,6 +171,7 @@ item.rune.defense.name=Rune of Defense
 item.rune.magic.name=Rune of Magic
 item.rune.void.name=Rune of Void
 
+item.charm.name=Charm
 item.charm.basicpower.name=Charm of Power
 item.charm.basicpower.tooltip=+$0 damage
 item.charm.basicagility.name=Charm of Agility
@@ -209,6 +220,7 @@ item.charm.lastresort.name=Charm of Last Resort
 item.charm.lastresort.tooltip=Teleports $0 blocks away from finishing hit with cooldown of $1 seconds
 item.charm.cannotstack=This charm will not stack effects with other charms of this type!
 
+item.curse.name=Curse
 item.curse.eternal=Eternal
 item.curse.teleportation.name=Curse of Teleportation
 item.curse.confusion.name=Curse of Confusion
@@ -221,6 +233,8 @@ item.curse.decay.name=Curse of Decay
 item.curse.vampire.name=Curse of Vampire
 item.curse.rebound.name=Curse of Rebound
 item.curse.loss.name=Curse of Loss
+
+item.itemNumber.name=Number
 
 entity.dragon.name=Ender Dragon
 entity.dragon.bacon.name=Ender Bacon


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.