### PR TITLE
bandaid fix for chunk loading lag

### DIFF
--- a/src/main/java/chylex/hee/mechanics/energy/EnergyChunkData.java
+++ b/src/main/java/chylex/hee/mechanics/energy/EnergyChunkData.java
@@ -47,7 +47,7 @@ public class EnergyChunkData {
             energyLevel -= release;
             releaseTimer = (byte) (4 + rand.nextInt(7));
 
-            BlockPosM.tmp(x + rand.nextInt(16), 8 + rand.nextInt(116), z + rand.nextInt(16)).setBlock(
+            BlockPosM.tmp(x + rand.nextInt(16), 8 + rand.nextInt(116), z + rand.nextInt(16)).setBlockOnlyLoaded(
                     world,
                     BlockList.corrupted_energy_low,
                     MathUtil.clamp(MathUtil.floor(1F + release * 12F), 2, 8));

--- a/src/main/java/chylex/hee/system/util/BlockPosM.java
+++ b/src/main/java/chylex/hee/system/util/BlockPosM.java
@@ -202,6 +202,13 @@ public class BlockPosM {
         return world.setBlock(x, y, z, block, metadata, 3);
     }
 
+    public boolean setBlockOnlyLoaded(World world, Block block, int metadata) {
+        if (!world.blockExists(x, y, z)) {
+            return false;
+        }
+        return world.setBlock(x, y, z, block, metadata, 3);
+    }
+
     public boolean setBlock(World world, Block block, int metadata, int flags) {
         return world.setBlock(x, y, z, block, metadata, flags);
     }


### PR DESCRIPTION
this has been causing spontaneous lag (1000ms~4000ms for a particular tick then back to normal for a few seconds, then 1000ms+ again, then normal again, rinse and repeat) for some unknown reason on my server. applying this patch seems to get rid of that. 
I'm not entirely sure what I'm doing, but I'm pretty confident this does not break anything obvious. If someone can obsolete this PR with a more comprehensive solution then please go ahead