### PR TITLE
Fix a Haunted Miner research requiring itself

### DIFF
--- a/src/main/java/chylex/hee/mechanics/compendium/KnowledgeRegistrations.java
+++ b/src/main/java/chylex/hee/mechanics/compendium/KnowledgeRegistrations.java
@@ -1191,7 +1191,7 @@ public final class KnowledgeRegistrations {
                         HAUNTED_MINER.setPos(0, 13).setUnlockPrice(25).setDiscoveryReward(15).addFragments(
                                 new KnowledgeFragment[] {
                                         new KnowledgeFragmentText(650).setPrice(7).setUnlockOnDiscovery(),
-                                        new KnowledgeFragmentText(651).setPrice(7).setUnlockRequirements(651),
+                                        new KnowledgeFragmentText(651).setPrice(7).setUnlockRequirements(650),
                                         new KnowledgeFragmentText(652).setPrice(4).setUnlockRequirements(650),
                                         new KnowledgeFragmentText(653).setPrice(4).setUnlockRequirements(650),
                                         new KnowledgeFragmentText(654).setPrice(4).setUnlockRequirements(653),


### PR DESCRIPTION
The second inner-research for the Haunted Miner currently requires itself to be unlocked in order to unlock it, so this PR makes it require the outer-research like the one inner-research above and two below it.

Before PR (all other research is unlocked):
<img width="826" height="826" alt="image" src="https://github.com/user-attachments/assets/8e8fe70a-c05d-40f0-941f-710d23da32cc" />

After PR:
<img width="826" height="826" alt="image" src="https://github.com/user-attachments/assets/20c85d3e-e769-445f-82ba-9df465494296" />
