### PR TITLE
Fixed HEE Spatial Dash Gem Capacity Enhancement to extend uses

### DIFF
--- a/src/main/java/chylex/hee/item/ItemSpatialDashGem.java
+++ b/src/main/java/chylex/hee/item/ItemSpatialDashGem.java
@@ -57,7 +57,8 @@ public class ItemSpatialDashGem extends ItemAbstractEnergyAcceptor {
 
     @Override
     public ItemStack onItemRightClick(ItemStack is, World world, EntityPlayer player) {
-        if (is.getItemDamage() < getMaxDamage() && (!is.hasTagCompound() || !is.getTagCompound().hasKey("cooldown"))) {
+        if (is.getItemDamage() < is.getMaxDamage()
+                && (!is.hasTagCompound() || !is.getTagCompound().hasKey("cooldown"))) {
             if (!world.isRemote) {
                 CausatumUtils.increase(player, CausatumMeters.ITEM_USAGE, 0.5F);
                 damageItem(is, player);


### PR DESCRIPTION
This PR fixes the Spatial Dash Gem so it correctly takes into account the capacity enhancement by using the override of getMaxDamage(). (Testing was done through breakpoints, and it does go through the override inside ItemSpatialDashGem)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23240.