### PR TITLE
Add localization for Compendium titles and point amount(optional)

### DIFF
--- a/src/main/java/chylex/hee/gui/GuiEnderCompendium.java
+++ b/src/main/java/chylex/hee/gui/GuiEnderCompendium.java
@@ -15,6 +15,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
@@ -547,8 +548,8 @@ public class GuiEnderCompendium extends GuiScreen implements ITooltipRenderer {
         drawTexturedModalRect(d - 16, height - d - 8, 0, 25, 24, 24);
         drawTexturedModalRect(width - d - 8, height - d - 8, 25, 25, 24, 24);
 
-        String title = ModCommonProxy.hardcoreEnderbacon ? "Hardcore Bacon Expansion - Bacon Compendium"
-                : "Hardcore Ender Expansion - Ender Compendium";
+        String title = ModCommonProxy.hardcoreEnderbacon ? I18n.format("ec.title.main.bacon")
+                : I18n.format("ec.title.main");
         fontRendererObj.drawString(title, (width >> 1) - (fontRendererObj.getStringWidth(title) >> 1), 14, 0x404040);
 
         GL11.glEnable(GL11.GL_DEPTH_TEST);
@@ -565,7 +566,11 @@ public class GuiEnderCompendium extends GuiScreen implements ITooltipRenderer {
         renderItem.renderItemIntoGUI(fontRendererObj, mc.getTextureManager(), knowledgeFragmentIS, x + 3, y + 1);
 
         String pointAmount = String.valueOf(compendiumData.getPoints());
-        fontRendererObj.drawString(pointAmount, x + 50 - fontRendererObj.getStringWidth(pointAmount), y + 6, 0x404040);
+        String pointAmountText = StatCollector.canTranslate("ec.pointAmount")
+                ? I18n.format("ec.pointAmount", pointAmount)
+                : pointAmount;
+        fontRendererObj
+                .drawString(pointAmountText, x + 50 - fontRendererObj.getStringWidth(pointAmountText), y + 6, 0x404040);
 
         GL11.glEnable(GL11.GL_DEPTH_TEST);
     }

--- a/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/en_US.lang
@@ -1,3 +1,6 @@
+ec.title.main=Hardcore Ender Expansion - Ender Compendium
+ec.title.main.bacon=Hardcore Bacon Expansion - Bacon Compendium
+
 ec.title.stronghold=Stronghold
 ec.title.dragonLair=Dragon Lair
 ec.title.endstoneBlob=Endstone Blob

--- a/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/ru_RU.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/ru_RU.lang
@@ -1,3 +1,6 @@
+ec.title.main=Hardcore Ender Expansion - Ender Compendium
+ec.title.main.bacon=Hardcore Bacon Expansion - Bacon Compendium
+
 ec.title.stronghold=Крепость
 ec.title.dragonLair=Логово Дракона
 ec.title.endstoneBlob=Эндер-остров

--- a/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/zh_CN.lang
+++ b/src/main/resources/assets/hardcoreenderexpansion/lang/compendium/zh_CN.lang
@@ -1,6 +1,8 @@
 # Update by Athloniux for v1.8.6
 # Thanks to Yoooo And Rudis From NGACraft
 # Proofread by Kiwi233
+ec.title.main=Hardcore Ender Expansion - Ender Compendium
+ec.title.main.bacon=Hardcore Bacon Expansion - Bacon Compendium
 
 ec.title.stronghold=要塞
 ec.title.dragonLair=龙巢


### PR DESCRIPTION
Added localization for main title(s) of the Compendium and optional resoruce pack color override for pointAmount with `ec.pointAmount=§4%s` (if not present, fallback to default), nothing broken, all good, cheers.

Example

<img width="997" height="281" alt="Example" src="https://github.com/user-attachments/assets/d7b50e1d-3a8e-469a-a15a-b39e52b7f794" />
