### PR TITLE
fix(sound): wrap vanilla music ticker instead of discarding it

### DIFF
--- a/src/main/java/chylex/hee/sound/MusicManager.java
+++ b/src/main/java/chylex/hee/sound/MusicManager.java
@@ -36,11 +36,13 @@ public final class MusicManager {
         if (mcMusicTicker != null) {
             Class<? extends MusicTicker> tickerClass = mcMusicTicker.getClass();
 
+            // Wrap the existing ticker instead of discarding it, so vanilla music (and any mixins on
+            // MusicTicker.update) still runs when removeVanillaDelay is off.
+            ReflectionUtils.setFieldValue(mc, "mcMusicTicker", new CustomMusicTicker(mc, mcMusicTicker));
+
             if (tickerClass == MusicTicker.class) {
-                ReflectionUtils.setFieldValue(mc, "mcMusicTicker", new CustomMusicTicker(mc, null));
-                Log.info("Successfully replaced music system.");
+                Log.info("Successfully wrapped the vanilla music system.");
             } else {
-                ReflectionUtils.setFieldValue(mc, "mcMusicTicker", new CustomMusicTicker(mc, mcMusicTicker));
                 Log.info("Successfully wrapped a music system replaced by another mod: $0", tickerClass.getName());
             }
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/Hodgepodge/issues/915

## Summary
Passing null for a pure-vanilla ticker discarded it and ran HEE's own updateVanillaMusic, so vanilla MusicTicker.update never ticked and any mixins other mods apply to it (e.g. a configurable music delay) never ran. Wrap it so overworld music delegates to the real ticker when removeVanillaDelay is off.


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
