### PR TITLE
Add config to disable special dragon egg pickup (#26073)

### DIFF
--- a/src/main/java/chylex/hee/block/BlockDragonEggCustom.java
+++ b/src/main/java/chylex/hee/block/BlockDragonEggCustom.java
@@ -30,6 +30,9 @@ import chylex.hee.system.util.BlockPosM;
 
 public class BlockDragonEggCustom extends BlockDragonEgg {
 
+    /** When true, keep HEE special pickup (shift+sword). When false, use vanilla-like interaction. */
+    public static boolean enableSpecialDragonEggPickup = false;
+
     public BlockDragonEggCustom() {
         setBlockUnbreakable().setResistance(2000F).setStepSound(Block.soundTypeStone).setLightLevel(0.125F)
                 .setBlockName("dragonEgg").setBlockTextureName("dragon_egg");
@@ -75,6 +78,11 @@ public class BlockDragonEggCustom extends BlockDragonEgg {
 
     @Override
     public void onBlockClicked(World world, int x, int y, int z, EntityPlayer player) {
+        if (!enableSpecialDragonEggPickup) {
+            super.onBlockClicked(world, x, y, z, player);
+            return;
+        }
+
         if (player != null && player.isSneaking()
                 && player.getHeldItem() != null
                 && player.getHeldItem().getItemUseAction() == EnumAction.block) {
@@ -86,27 +94,49 @@ public class BlockDragonEggCustom extends BlockDragonEgg {
     @Override
     public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX,
             float hitY, float hitZ) {
+        if (!enableSpecialDragonEggPickup) {
+            return super.onBlockActivated(world, x, y, z, player, side, hitX, hitY, hitZ);
+        }
+
         teleportNearby(world, x, y, z);
         return true;
     }
 
     @Override
     public void dropBlockAsItemWithChance(World world, int x, int y, int z, int meta, float chance, int fortune) {
+        if (!enableSpecialDragonEggPickup) {
+            super.dropBlockAsItemWithChance(world, x, y, z, meta, chance, fortune);
+            return;
+        }
+
         teleportNearby(world, x, y, z);
     }
 
     @Override
     public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
+        if (!enableSpecialDragonEggPickup) {
+            super.breakBlock(world, x, y, z, block, meta);
+            return;
+        }
+
         teleportNearby(world, x, y, z);
     }
 
     @Override
     public Item getItemDropped(int meta, Random rand, int fortune) {
+        if (!enableSpecialDragonEggPickup) {
+            return super.getItemDropped(meta, rand, fortune);
+        }
+
         return null;
     }
 
     @Override
     public int quantityDropped(Random rand) {
+        if (!enableSpecialDragonEggPickup) {
+            return super.quantityDropped(rand);
+        }
+
         return 0;
     }
 

--- a/src/main/java/chylex/hee/entity/block/EntityBlockFallingDragonEgg.java
+++ b/src/main/java/chylex/hee/entity/block/EntityBlockFallingDragonEgg.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
 import chylex.hee.block.BlockDragonEggCustom;
@@ -68,9 +69,13 @@ public class EntityBlockFallingDragonEgg extends EntityFallingBlock {
     }
 
     private void die() {
-        if (!worldObj.isRemote && !BlockDragonEggCustom
-                .teleportNearby(worldObj, MathUtil.floor(posX), MathUtil.floor(posY), MathUtil.floor(posZ))) {
-            BlockDragonEggCustom.teleportEntityToPortal(this);
+        if (!worldObj.isRemote) {
+            if (!BlockDragonEggCustom.enableSpecialDragonEggPickup) {
+                entityDropItem(new ItemStack(Blocks.dragon_egg), 0.0F);
+            } else if (!BlockDragonEggCustom
+                    .teleportNearby(worldObj, MathUtil.floor(posX), MathUtil.floor(posY), MathUtil.floor(posZ))) {
+                BlockDragonEggCustom.teleportEntityToPortal(this);
+            }
         }
 
         setDead();

--- a/src/main/java/chylex/hee/system/ConfigHandler.java
+++ b/src/main/java/chylex/hee/system/ConfigHandler.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.config.Property;
 
 import chylex.hee.HardcoreEnderExpansion;
 import chylex.hee.api.HeeIMC;
+import chylex.hee.block.BlockDragonEggCustom;
 import chylex.hee.block.BlockEnderGoo;
 import chylex.hee.item.ItemTempleCaller;
 import chylex.hee.mechanics.compendium.content.fragments.KnowledgeFragmentText;
@@ -146,6 +147,10 @@ public final class ConfigHandler {
                 "enableTempleCaller",
                 true,
                 "Mechanic that allows players to reset the End, may not be desirable on servers.");
+        BlockDragonEggCustom.enableSpecialDragonEggPickup = getBoolValue(
+                "enableSpecialDragonEggPickup",
+                false,
+                "When enabled, dragon eggs teleport on interaction and can only be picked up by sneaking with a sword. When disabled, vanilla-like behavior is restored so torch/falling sand pickup works.");
         Log.forceDebugEnabled = getBool(
                 "logDebuggingInfo",
                 false,


### PR DESCRIPTION
## Summary
- Add `enableSpecialDragonEggPickup` (default **false**)
- When disabled, restore vanilla-like dragon egg interaction so torch/falling-sand pickup works
- When enabled, keep HEE shift+sword pickup behavior
- Fixes GTNewHorizons/GT-New-Horizons-Modpack#26073

## Test plan
- [ ] With default config, pick up dragon egg via torch/falling sand
- [ ] Set `enableSpecialDragonEggPickup=true`, confirm shift+sword still required / teleport behavior returns

Made with [Cursor](https://cursor.com)