### PR TITLE
Add config to re-enable vanilla dragon egg pickup mechanics

### DIFF
--- a/src/main/java/chylex/hee/block/BlockDragonEggCustom.java
+++ b/src/main/java/chylex/hee/block/BlockDragonEggCustom.java
@@ -30,6 +30,8 @@ import chylex.hee.system.util.BlockPosM;
 
 public class BlockDragonEggCustom extends BlockDragonEgg {
 
+    public static boolean allowVanillaDragonEggPickup = false;
+
     public BlockDragonEggCustom() {
         setBlockUnbreakable().setResistance(2000F).setStepSound(Block.soundTypeStone).setLightLevel(0.125F)
                 .setBlockName("dragonEgg").setBlockTextureName("dragon_egg");
@@ -37,7 +39,9 @@ public class BlockDragonEggCustom extends BlockDragonEgg {
 
     @Override
     public void updateTick(World world, int x, int y, int z, Random rand) {
-        fallIfPossible(world, x, y, z);
+        // Use the regular logic when the vanilla pickup is enabled.
+        if (allowVanillaDragonEggPickup) super.updateTick(world, x, y, z, rand);
+        else fallIfPossible(world, x, y, z);
     }
 
     @Override

--- a/src/main/java/chylex/hee/system/ConfigHandler.java
+++ b/src/main/java/chylex/hee/system/ConfigHandler.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.config.Property;
 
 import chylex.hee.HardcoreEnderExpansion;
 import chylex.hee.api.HeeIMC;
+import chylex.hee.block.BlockDragonEggCustom;
 import chylex.hee.block.BlockEnderGoo;
 import chylex.hee.item.ItemTempleCaller;
 import chylex.hee.mechanics.compendium.content.fragments.KnowledgeFragmentText;
@@ -146,6 +147,10 @@ public final class ConfigHandler {
                 "enableTempleCaller",
                 true,
                 "Mechanic that allows players to reset the End, may not be desirable on servers.");
+        BlockDragonEggCustom.allowVanillaDragonEggPickup = getBoolValue(
+                "allowVanillaDragonEggPickup",
+                false,
+                "Re-enables the vanilla dragon egg pickup mechanic.");
         Log.forceDebugEnabled = getBool(
                 "logDebuggingInfo",
                 false,


### PR DESCRIPTION
## Summary
This PR is a cleaner implementation of #44 and would resolve the same linked issue.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26073

### Changes:
Added a new config called `allowVanillaDragonEggPickup` that re-enables the vanilla dragon egg pickup mechanic. The original sword mechanic is preserved, and the default value is set to false to keep the integrity of the original functionality.

### Preview:

With the config enabled:

https://github.com/user-attachments/assets/490a79a9-8f4e-4c81-9a94-73ab7711c35f

With the config disabled (default setting, original functionality):

https://github.com/user-attachments/assets/7e5efd9b-e2b7-4c97-bfce-795f60c399ac

### Additional notes
- The current method of implementation for the HEE dragon egg could probably be simplified down to a mixin or, at the very least, be shrunk in size since a lot of the code is actually just replicated vanilla code.
- The creeper egg should probably be updated at some point to be consistent, allowing it to also be picked up with a sword while sneaking.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - No AI used. 
- ❌ This PR requires another PR in order to merge
